### PR TITLE
문서 카테고리명 및 표시 순서 수정

### DIFF
--- a/docs/docs_index.py
+++ b/docs/docs_index.py
@@ -1,5 +1,15 @@
 book_structure = {
-    '초급': [
+    '통계학습': [
+        {'title': '서문', 'file': 'advanced/01_preface.md'},
+        {'title': '탐색적 데이터 분석', 'file': 'advanced/02_eda.md'},
+        {'title': '데이터 및 표본 분포', 'file': 'advanced/03_sampling.md'},
+        {'title': '통계적 실험 및 유의성 검정', 'file': 'advanced/04_experiments.md'},
+        {'title': '회귀 및 예측', 'file': 'advanced/05_regression.md'},
+        {'title': '분류', 'file': 'advanced/06_classification.md'},
+        {'title': '통계적 기계 학습', 'file': 'advanced/07_machine_learning.md'},
+        {'title': '비지도 학습', 'file': 'advanced/08_unsupervised.md'}
+    ],
+    '연구방법론': [
         {'title': '배경 정보', 'file': 'beginner/01_background.md'},
         {'title': '질적 연구와 양적 연구', 'file': 'beginner/02_qualitative.md'},
         {'title': '무대 설정', 'file': 'beginner/03_setting_the_stage.md'},
@@ -14,20 +24,10 @@ book_structure = {
         {'title': '사례 연구 제안서 준비', 'file': 'beginner/12_proposals.md'},
         {'title': '사례 연구 결과 보급', 'file': 'beginner/13_dissemination.md'}
     ],
-    '중급': [
+    '요인분석 이론': [
         {'title': '서론', 'file': 'intermediate/01_intro.md'},
         {'title': '직접 요인 분석 이론', 'file': 'intermediate/02_theory.md'},
         {'title': 'K-방향 척도 분석 예시', 'file': 'intermediate/03_miniature_example.md'},
         {'title': '논의', 'file': 'intermediate/04_discussion.md'}
-    ],
-    '고급': [
-        {'title': '서문', 'file': 'advanced/01_preface.md'},
-        {'title': '탐색적 데이터 분석', 'file': 'advanced/02_eda.md'},
-        {'title': '데이터 및 표본 분포', 'file': 'advanced/03_sampling.md'},
-        {'title': '통계적 실험 및 유의성 검정', 'file': 'advanced/04_experiments.md'},
-        {'title': '회귀 및 예측', 'file': 'advanced/05_regression.md'},
-        {'title': '분류', 'file': 'advanced/06_classification.md'},
-        {'title': '통계적 기계 학습', 'file': 'advanced/07_machine_learning.md'},
-        {'title': '비지도 학습', 'file': 'advanced/08_unsupervised.md'}
     ]
 }


### PR DESCRIPTION
## 요약
- `book_structure`의 키를 `통계학습`, `연구방법론`, `요인분석 이론`으로 변경
- 사전 정의 순서도 변경하여 웹 페이지에서 "통계학습→연구방법론→요인분석 이론" 순으로 보이도록 조정

## 테스트
- `python3 validate_docs.py` 실행하여 모든 문서가 존재함을 확인

------
https://chatgpt.com/codex/tasks/task_e_685a2328c1708324b045703234afc12c