### PR TITLE
프론트엔드 개선 및 공개 데이터 활용

### DIFF
--- a/modules/data_processing.py
+++ b/modules/data_processing.py
@@ -1,4 +1,5 @@
 import pandas as pd
+import seaborn as sns
 
 
 def generate_statistics_data(size=50):
@@ -9,3 +10,21 @@ def generate_statistics_data(size=50):
         'y': rng.sample(frac=1, random_state=42).reset_index(drop=True)
     })
     return data
+
+
+def load_public_dataset():
+    """공개된 Iris 데이터셋을 로드"""
+    return sns.load_dataset('iris')
+
+
+def prepare_scatter_datasets(df, x_col, y_col, color_map):
+    """주어진 컬럼 쌍으로 차트용 데이터셋을 준비"""
+    datasets = []
+    for species, group in df.groupby('species'):
+        sample = group[[x_col, y_col]].rename(columns={x_col: 'x', y_col: 'y'})
+        datasets.append({
+            'label': species,
+            'data': sample.to_dict(orient='records'),
+            'backgroundColor': color_map.get(species, 'rgba(0,0,0,0.6)')
+        })
+    return datasets

--- a/templates/index.html
+++ b/templates/index.html
@@ -3,14 +3,22 @@
 <head>
     <meta charset="utf-8">
     <title>Practical Statistics</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.1/dist/css/bootstrap.min.css" rel="stylesheet">
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.1/dist/js/bootstrap.bundle.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
     <style>
-    .accordion {margin-bottom: 1em;}
-    .panel {display:none; padding: 1em; border: 1px solid #ccc;}
-    .active + .panel {display:block;}
+    .accordion-button {cursor:pointer;}
     </style>
     <script>
+    function createChart(id, datasets) {
+        new Chart(document.getElementById(id), {
+            type: 'scatter',
+            data: { datasets: datasets },
+            options: {responsive:true}
+        });
+    }
     document.addEventListener('DOMContentLoaded', () => {
-        document.querySelectorAll('.accordion').forEach(btn => {
+        document.querySelectorAll('.accordion-button').forEach(btn => {
             btn.addEventListener('click', () => {
                 btn.classList.toggle('active');
                 const panel = btn.nextElementSibling;
@@ -24,14 +32,25 @@
     });
     </script>
 </head>
-<body>
-<h1>통계 학습 데모</h1>
-<img src="data:image/png;base64,{{ image }}" alt="통계 그래프">
+<body class="container my-4">
+<h1 class="mb-4">통계 학습 데모</h1>
 {% for book, sections in books.items() %}
-    <h2>{{ book }}</h2>
+    <h2 class="mt-3">{{ book }}</h2>
     {% for sec in sections %}
-        <button class="accordion">{{ sec.title }}</button>
-        <div class="panel">{{ sec.content|safe }}</div>
+        <button class="accordion-button btn btn-secondary w-100 text-start mt-2">{{ sec.title }}</button>
+        <div class="panel" style="display:none;">
+            <h3>개념의 이해</h3>
+            {{ sec.content|safe }}
+            {% if sec.code %}
+            <h3>계산식</h3>
+            <pre><code>{{ sec.code }}</code></pre>
+            {% endif %}
+            <h3>시각화 ({{ sec.x }} vs {{ sec.y }})</h3>
+            <canvas id="chart-{{ loop.parentloop.index0 }}-{{ loop.index0 }}" height="200"></canvas>
+            <script>
+            createChart('chart-{{ loop.parentloop.index0 }}-{{ loop.index0 }}', {{ sec.chart|tojson }});
+            </script>
+        </div>
     {% endfor %}
 {% endfor %}
 </body>

--- a/webapp.py
+++ b/webapp.py
@@ -2,28 +2,62 @@ from flask import Flask, render_template
 import markdown
 import os
 from docs.docs_index import book_structure
-from modules import data_processing, visualization
+from modules import data_processing
+
+
+COLORS = {
+    'setosa': 'rgba(255,99,132,0.6)',
+    'versicolor': 'rgba(54,162,235,0.6)',
+    'virginica': 'rgba(75,192,192,0.6)'
+}
 
 app = Flask(__name__)
 
 
 def load_markdown(path):
+    """마크다운 파일을 읽어 HTML과 코드 블록을 반환"""
     with open(os.path.join('docs', path), 'r', encoding='utf-8') as f:
         text = f.read()
-    return markdown.markdown(text)
+    code = ""
+    if "```" in text:
+        parts = text.split("```")
+        if len(parts) >= 2:
+            code = parts[1].strip()
+    html = markdown.markdown(text, extensions=['fenced_code'])
+    return html, code
 
 
 @app.route('/')
 def index():
     books = {}
+    public_df = data_processing.load_public_dataset()
+    feature_pairs = [
+        ('sepal_length', 'sepal_width'),
+        ('petal_length', 'petal_width'),
+        ('sepal_length', 'petal_length'),
+        ('sepal_width', 'petal_width'),
+    ]
+
+    pair_idx = 0
     for key, sections in book_structure.items():
         books[key] = []
         for sec in sections:
-            html = load_markdown(sec['file'])
-            books[key].append({'title': sec['title'], 'content': html})
-    data = data_processing.generate_statistics_data()
-    img = visualization.plot_statistics(data)
-    return render_template('index.html', books=books, image=img)
+            html, code = load_markdown(sec['file'])
+            x_col, y_col = feature_pairs[pair_idx % len(feature_pairs)]
+            pair_idx += 1
+            datasets = data_processing.prepare_scatter_datasets(
+                public_df, x_col, y_col, COLORS
+            )
+            books[key].append({
+                'title': sec['title'],
+                'content': html,
+                'code': code,
+                'chart': datasets,
+                'x': x_col,
+                'y': y_col,
+            })
+
+    return render_template('index.html', books=books)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## 변경 내용
- `data_processing.py`에 차트용 데이터셋 생성 함수 추가
- 웹앱에서 섹션별로 Iris 데이터의 서로 다른 변수 조합을 사용하여 차트를 표시하도록 수정
- 마크다운 로딩 시 코드 블록을 분리하여 '개념의 이해-계산식-시각화' 구조로 렌더링
- 템플릿에서 각 섹션에 개념, 계산식, 시각화 차트를 포함하도록 개편

## 테스트
- `python -m py_compile webapp.py modules/data_processing.py modules/visualization.py modules/widgets.py`
- `python validate_docs.py`


------
https://chatgpt.com/codex/tasks/task_e_685a6239397c832488c468671cd7e1a6